### PR TITLE
feat: 가나다 순으로 캘린더 정렬

### DIFF
--- a/EazyCal/Store/EventStore.swift
+++ b/EazyCal/Store/EventStore.swift
@@ -20,7 +20,13 @@ class EventStore: ObservableObject {
             guard try await eventStore.requestFullAccessToEvents() else { return []}
             
             let calendars = self.eventStore.calendars(for: .event)
-            result = calendars
+            let notTitle = calendars.filter { $0.title == "무제" || $0.title == "Untitled" }
+            let existTitle = calendars.filter { $0.title != "무제" && $0.title != "Untitled" }
+            
+            result += existTitle.sorted(by: {
+                    $0.title < $1.title
+            })
+            result += notTitle
         } catch {
             return []
         }


### PR DESCRIPTION
# 이슈
- #20

# 한 일
- 캘린더 생성 날짜가 없어 생성날짜로 할 수 없음
- 이름없는 캘린더는 마지막으로
- 가나다 순으로 캘린더 정렬